### PR TITLE
set tooltip explicitly when href is set, otherwise tooltip shows \N

### DIFF
--- a/src/sbt-test/sbt-class-diagram/simple/build.sbt
+++ b/src/sbt-test/sbt-class-diagram/simple/build.sbt
@@ -6,14 +6,18 @@ scalaVersion := "2.11.6"
 
 libraryDependencies += "org.scalaz" %% "scalaz-core" % scalazVersion
 
-val urlMapping: PartialFunction[Class[_], String] = {
-  case clazz if clazz.getName.startsWith("scalaz") =>
-    s"https://github.com/scalaz/scalaz/tree/v${scalazVersion}/core/src/main/scala/${clazz.getName.replace('.', '/')}.scala"
-}
+def urlMap(clazz: Class[_]): Map[String, String] =
+  if (clazz.getName.startsWith("scalaz"))
+    Map(
+      "href" -> s"https://github.com/scalaz/scalaz/tree/v${scalazVersion}/core/src/main/scala/${clazz.getName.replace('.', '/')}.scala",
+      "tooltip" -> clazz.getName
+    )
+  else
+    Map()
 
 DiagramKeys.classDiagramSetting ~= { s =>
   s.copy(
-    nodeSetting = clazz => s.nodeSetting(clazz) ++ urlMapping.lift(clazz).map("href" -> _).toList,
+    nodeSetting = clazz => s.nodeSetting(clazz) ++ urlMap(clazz),
     commonNodeSetting = s.commonNodeSetting + ("target" -> "_blank")
   )
 }


### PR DESCRIPTION
Small fix for the Scalaz sample. It showed '\N' as tooltip. I changed it to be the class name.